### PR TITLE
Fix server TypeScript compilation errors

### DIFF
--- a/apps/server/src/routes/phases/combatMove.ts
+++ b/apps/server/src/routes/phases/combatMove.ts
@@ -8,7 +8,7 @@
 
 import type { FastifyInstance } from "fastify";
 import { z } from "zod";
-import { TurnPhase, isValidCombatMove, TERRITORIES } from "@aa/shared";
+import { TurnPhase, PowerName, isValidCombatMove, TERRITORIES } from "@aa/shared";
 import type { TerritoryNode, GameTerritoryState } from "@aa/shared";
 import { requireAuth } from "../../auth/middleware.js";
 import { assertActivePlayer, getCurrentTurn } from "../../services/gameService.js";

--- a/apps/server/tsconfig.json
+++ b/apps/server/tsconfig.json
@@ -6,5 +6,5 @@
     "module": "NodeNext",
     "moduleResolution": "NodeNext"
   },
-  "include": ["src", "prisma"]
+  "include": ["src"]
 }


### PR DESCRIPTION
- tsconfig.json: remove 'prisma' from include; seed.ts is a dev-only script run via tsx and should not be compiled by tsc (rootDir is ./src, so including prisma/ caused TS6059)
- combatMove.ts: add missing PowerName import from @aa/shared; was used in a type assertion on line 68 but not imported, causing TS2304

Also ran prisma generate so Prisma client types are now present; all other @prisma/client member errors were due to the client not being generated rather than code bugs.

https://claude.ai/code/session_01RVub2NVJ7iaPK3CPSVy6Jp