### PR TITLE
Fix Dockerfile: run prisma generate before tsc build

### DIFF
--- a/apps/server/Dockerfile
+++ b/apps/server/Dockerfile
@@ -18,9 +18,10 @@ COPY apps/server ./apps/server
 COPY tsconfig.base.json ./
 
 # Build shared package then server
+# prisma generate must run before tsc so Prisma client types exist during compilation
 RUN pnpm --filter @aa/shared build
-RUN pnpm --filter @aa/server build
 RUN pnpm --filter @aa/server exec prisma generate
+RUN pnpm --filter @aa/server build
 
 # ── Stage 2: production ───────────────────────────────────────────────────────
 FROM node:20-alpine AS production


### PR DESCRIPTION
Without generated Prisma client types, tsc cannot resolve @prisma/client members (PrismaClient, model types, enums) and produces dozens of errors. Moving prisma generate ahead of the build step ensures types are available when the TypeScript compiler runs.

https://claude.ai/code/session_01RVub2NVJ7iaPK3CPSVy6Jp