### PR TITLE
Fix Dockerfile production stage: prisma CLI available at runtime

### DIFF
--- a/apps/server/Dockerfile
+++ b/apps/server/Dockerfile
@@ -35,14 +35,16 @@ COPY package.json pnpm-workspace.yaml pnpm-lock.yaml* ./
 COPY --from=builder /app/packages/shared/package.json ./packages/shared/
 COPY --from=builder /app/apps/server/package.json ./apps/server/
 
-# Install production dependencies only
+# Install production dependencies only (prisma is a dependency so it's included)
 RUN pnpm install --frozen-lockfile --prod
 
-# Copy built output and prisma schema (needed at runtime by prisma client)
+# Copy built output and prisma schema
 COPY --from=builder /app/packages/shared/dist ./packages/shared/dist
 COPY --from=builder /app/apps/server/dist ./apps/server/dist
 COPY --from=builder /app/apps/server/prisma ./apps/server/prisma
-COPY --from=builder /app/node_modules/.pnpm ./node_modules/.pnpm
+
+# Generate Prisma client against the production node_modules
+RUN pnpm --filter @aa/server exec prisma generate
 
 EXPOSE 3001
 

--- a/apps/server/package.json
+++ b/apps/server/package.json
@@ -13,6 +13,7 @@
   "dependencies": {
     "@aa/shared": "workspace:*",
     "@prisma/client": "^5.15.0",
+    "prisma": "^5.15.0",
     "fastify": "^4.27.0",
     "@fastify/cookie": "^9.3.1",
     "@fastify/cors": "^9.0.1",
@@ -26,7 +27,6 @@
   "devDependencies": {
     "@types/bcrypt": "^5.0.2",
     "@types/node": "^20.14.2",
-    "prisma": "^5.15.0",
     "tsx": "^4.15.7",
     "typescript": "^5.4.5"
   }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -41,6 +41,9 @@ importers:
       lucia:
         specifier: ^3.2.0
         version: 3.2.2
+      prisma:
+        specifier: ^5.15.0
+        version: 5.22.0
       resend:
         specifier: ^3.3.0
         version: 3.5.0(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
@@ -57,9 +60,6 @@ importers:
       '@types/node':
         specifier: ^20.14.2
         version: 20.19.39
-      prisma:
-        specifier: ^5.15.0
-        version: 5.22.0
       tsx:
         specifier: ^4.15.7
         version: 4.21.0


### PR DESCRIPTION
Two problems in the production stage:
1. prisma was a devDependency, so pnpm install --prod omitted it, making both prisma generate and prisma migrate deploy unavailable at container startup.
2. COPY node_modules/.pnpm from builder was copying the full dev dependency tree into production, negating the --prod install and bloating the image.

Fix:
- Move prisma to dependencies so it is installed in --prod mode
- Remove the .pnpm copy from builder
- Add prisma generate to the production stage (after pnpm install --prod) so the client is generated against the production store
- prisma migrate deploy in CMD continues to work as before

https://claude.ai/code/session_01RVub2NVJ7iaPK3CPSVy6Jp