### PR TITLE
Fix Prisma OpenSSL error on Alpine and remove obsolete compose version

### DIFF
--- a/apps/server/Dockerfile
+++ b/apps/server/Dockerfile
@@ -1,6 +1,9 @@
 # ── Stage 1: builder ──────────────────────────────────────────────────────────
 FROM node:20-alpine AS builder
 
+# Prisma's schema engine requires OpenSSL on Alpine
+RUN apk add --no-cache openssl
+
 RUN corepack enable && corepack prepare pnpm@latest --activate
 
 WORKDIR /app
@@ -25,6 +28,9 @@ RUN pnpm --filter @aa/server build
 
 # ── Stage 2: production ───────────────────────────────────────────────────────
 FROM node:20-alpine AS production
+
+# Prisma's schema engine and query engine require OpenSSL on Alpine
+RUN apk add --no-cache openssl
 
 RUN corepack enable && corepack prepare pnpm@latest --activate
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,5 +1,3 @@
-version: '3.9'
-
 services:
   postgres:
     image: postgres:16-alpine


### PR DESCRIPTION
Prisma's schema engine and query engine are dynamically linked against OpenSSL, which is not present by default on node:20-alpine. Without it the engine binary fails to load, producing the misleading JSON parse error seen in the logs.

Fix: add `apk add --no-cache openssl` to both builder and production stages so Prisma can detect and link against the system OpenSSL at both build time (prisma generate) and runtime (prisma migrate deploy).

Also remove the obsolete `version: '3.9'` key from docker-compose.yml to silence the compose warning.

https://claude.ai/code/session_01RVub2NVJ7iaPK3CPSVy6Jp